### PR TITLE
Improve docs and class descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# RL_project
+# RL Project
+
+This repository contains a collection of reinforcement learning training routines and neural network models used for a university course project. The code implements agents such as PPO, DDPG, GRPO and an Active Inference based approach.
+
+## Repository Structure
+
+```
+models/           # Neural networks and agent utilities
+train_routines/   # Training loops for each algorithm
+*.ipynb           # Example notebooks
+```
+
+## Getting Started
+
+The code assumes a Python 3 environment with `torch` and `einops` installed. You can run any of the training scripts in `train_routines` by creating the corresponding agent and environment.
+
+Example:
+
+```python
+from train_routines.PPO import PPO
+# create your environment and networks here
+trainer = PPO(actor, critic, env, mem_args)
+trainer.train(episodes=100)
+```
+
+## Contributing
+
+This project is used for learning purposes but improvements are welcome. Please open an issue or pull request if you find a bug.
+
+## Code Style Suggestions
+
+Below are a few ideas for making the code easier to read and extend:
+
+- Introduce type hints to clarify the expected shapes of tensors.
+- Break down long functions into smaller helpers where possible.
+- Document the expected observation and action spaces for each environment.
+- Consider adopting a consistent naming convention for variables and classes.

--- a/models/networks.py
+++ b/models/networks.py
@@ -1,4 +1,5 @@
 # Extracted from https://github.com/alec-tschantz/rl-inference/blob/master/pmbrl/models/models.py
+"""Neural network modules used by the agents."""
 
 import torch
 import torch.nn as nn
@@ -13,6 +14,8 @@ def swish(x):
 
 
 class EnsembleDenseLayer(nn.Module):
+    """Fully connected layer replicated over an ensemble."""
+
     def __init__(self, in_size, out_size, ensemble_size, act_fn="swish"):
         super().__init__()
         self.in_size = in_size
@@ -51,6 +54,7 @@ class EnsembleDenseLayer(nn.Module):
 
 
 class EnsembleModel(nn.Module):
+    """Dynamics model consisting of multiple networks trained in parallel."""
     def __init__(
         self,
         in_size,
@@ -147,6 +151,7 @@ class EnsembleModel(nn.Module):
 
 
 class RewardModel(nn.Module):
+    """Simple feed-forward network used to predict immediate rewards."""
     def __init__(self, in_size, hidden_size, act_fn="relu", device="cpu"):
         super().__init__()
         self.in_size = in_size

--- a/models/utils.py
+++ b/models/utils.py
@@ -1,3 +1,5 @@
+"""Utility classes and functions for the RL models."""
+
 import torch
 import numpy as np
 from scipy.special import psi, gamma
@@ -5,6 +7,7 @@ from ele2364 import Memory
 from einops import rearrange, unpack
 
 class Memory_tensors(Memory):
+    """Replay buffer variant that returns tensors for each ensemble member."""
     def __init__(self,ensemble_size,**args):
         super().__init__(**args)
         self.ensemble_size=ensemble_size
@@ -29,6 +32,7 @@ class Memory_tensors(Memory):
 
 
 class InformationGain(object):
+    """Exploration bonus based on the ensemble's predictive disagreement."""
     def __init__(self, model, scale=1.0):
         self.model = model
         self.scale = scale
@@ -107,6 +111,7 @@ class InformationGain(object):
 
 
 class Normalizer(object):
+    """Online normalisation utility for states and actions."""
     def __init__(self):
         self.state_mean = None
         self.state_sk = None

--- a/train_routines/Active_inference.py
+++ b/train_routines/Active_inference.py
@@ -1,3 +1,5 @@
+"""Training loop for the Active Inference style agent."""
+
 import numpy as np
 import time
 from ele2364 import Memory
@@ -6,6 +8,29 @@ from models.Agents import EnsembleModel,RewardModel
 from tqdm.auto import tqdm
 
 class ActiveInference_trainer(object):
+    """Trainer for the planner-based Active Inference agent.
+
+    It alternates between collecting data using a model predictive
+    controller and training an ensemble dynamics model together with a
+    reward predictor. The resulting planner is then used to roll out new
+    trajectories, allowing the agent to gradually improve its internal
+    world model.
+
+    Parameters
+    ----------
+    agent : Planner
+        Agent implementing planning and action selection.
+    environment : gym.Env
+        Environment from which transitions are collected.
+    Memory : Memory
+        Replay buffer used to store data.
+    random_policy : Callable
+        Function returning random actions for exploration.
+    normalizer : callable
+        Online normalizer applied to observations.
+    model_learning_epochs : int
+        Number of training epochs for the ensemble model per episode.
+    """
     def __init__(self, agent,environment,Memory,random_policy,normalizer,model_learning_epochs):
         #parametric model implements trainin loops and reset weights routines and computation of actions
         self.env=environment

--- a/train_routines/DDPG.py
+++ b/train_routines/DDPG.py
@@ -1,4 +1,6 @@
 
+"""Deep Deterministic Policy Gradient training loop."""
+
 from random import choice
 from tqdm.auto import tqdm
 import matplotlib.pyplot as plt
@@ -12,6 +14,32 @@ import time
 #LAMBDA=0.97
 
 class DDPG(object):
+    """Trainer for the Deep Deterministic Policy Gradient algorithm.
+
+    This implementation maintains target actor and critic networks and
+    performs off–policy updates from a replay buffer. It exposes only
+    the essentials needed for the course assignments so that the logic
+    behind DDPG remains clear and easy to follow.
+
+    Parameters
+    ----------
+    actor : Mu
+        Actor network to be optimised.
+    critic : DQ
+        Critic network used for Q-value estimation.
+    actor_target : Mu
+        Target network mirroring ``actor``.
+    critic_target : DQ
+        Target network mirroring ``critic``.
+    gamma : float
+        Discount factor for future rewards.
+    environment : gym.Env
+        Environment providing transitions.
+    Memory : Memory
+        Replay buffer storing transitions.
+    model_learning_epochs : int
+        Number of gradient steps per episode.
+    """
 
     def __init__(self,actor,critic,actor_target,critic_target,gamma,environment,Memory,model_learning_epochs):
         self.env=environment

--- a/train_routines/GRPO.py
+++ b/train_routines/GRPO.py
@@ -1,4 +1,4 @@
-
+"""Implementation of the Gradient Reward Policy Optimization algorithm."""
 
 from random import choice
 import numpy as np
@@ -16,6 +16,22 @@ LAMBDA=0.97
 
 
 class GRPO(object):
+    """Trainer for the Gradient Reward Policy Optimization algorithm.
+
+    The trainer collects on-policy episodes and computes a simple
+    reward-based advantage signal which is then used to update the actor
+    network. The aim is to demonstrate policy gradient concepts with as
+    little overhead as possible.
+
+    Parameters
+    ----------
+    actor : Pi
+        Policy network to be trained.
+    environment : gym.Env
+        Environment that follows the Gym API.
+    mem_args : Sequence
+        Arguments used to create a :class:`ele2364.Memory` instance.
+    """
     def __init__(self,actor,environment,mem_args):
         self.env=environment
         self.actor=actor

--- a/train_routines/GRPO_mod.py
+++ b/train_routines/GRPO_mod.py
@@ -1,4 +1,4 @@
-
+"""Modified version of GRPO with additional state processing."""
 
 from random import choice
 import numpy as np
@@ -16,6 +16,22 @@ LAMBDA=0.97
 
 
 class GRPO_mod(object):
+    """Trainer for a modified GRPO algorithm with extra preprocessing.
+
+    This version reshapes experience into episode tensors and applies a
+    normalized reward signal before performing actor updates. It serves
+    as an example of how small tweaks to the data pipeline can change
+    learning behaviour.
+
+    Parameters
+    ----------
+    actor : Pi
+        Policy network to be trained.
+    environment : gym.Env
+        Environment object exposing ``reset`` and ``step``.
+    mem_args : Sequence
+        Arguments forwarded to :class:`ele2364.Memory`.
+    """
     def __init__(self,actor,environment,mem_args):
         self.env=environment
         self.actor=actor

--- a/train_routines/PPO.py
+++ b/train_routines/PPO.py
@@ -1,4 +1,4 @@
-
+"""Proximal Policy Optimization training loop."""
 
 from random import choice
 import numpy as np
@@ -15,6 +15,25 @@ LAMBDA=0.97
 
 
 class PPO(object):
+    """Trainer implementing a basic Proximal Policy Optimization loop.
+
+    The class collects transitions from the environment, computes
+    generalized advantage estimates and periodically updates the actor
+    and critic networks using minibatches sampled from an in-memory
+    buffer.  It is deliberately minimal and intended for educational
+    use rather than maximum performance.
+
+    Parameters
+    ----------
+    actor : Pi
+        Policy network used to select actions.
+    critic : V
+        Value network used for advantage estimation.
+    environment : gym.Env
+        Environment providing ``step`` and ``reset``.
+    mem_args : Sequence
+        Arguments forwarded to :class:`ele2364.Memory`.
+    """
     def __init__(self,actor,critic,environment,mem_args):
         self.env=environment
         self.actor=actor


### PR DESCRIPTION
## Summary
- add style suggestions section to README
- expand docstrings for trainers in ActiveInference, DDPG, GRPO, GRPO_mod, PPO

## Testing
- `python -m py_compile models/Agents.py models/networks.py models/utils.py train_routines/Active_inference.py train_routines/DDPG.py train_routines/GRPO.py train_routines/GRPO_mod.py train_routines/PPO.py`


------
https://chatgpt.com/codex/tasks/task_e_6871c7fa63a88331af3d5c4cd4d1ce78